### PR TITLE
Option consent_modal_equal_weight_buttons ermöglichen

### DIFF
--- a/fragments/wsm.js.php
+++ b/fragments/wsm.js.php
@@ -43,7 +43,7 @@ use rex_clang;
 				consentModal: {
 					layout: '<?= Wsm::getConfig('consent_settings_layout', 'string', '') ?>',
 					position: '<?= Wsm::getConfig('consent_modal_position', 'string', '') ?>',
-					equalWeightButtons: true,
+					equalWeightButtons: <?= Wsm::getConfig('consent_modal_equal_weight_buttons', 'bool') ? 'true' : 'false' ?>,
 					flipButtons: <?= Wsm::getConfig('consent_modal_swap_buttons', 'bool') ? 'true' : 'false' ?>,
 				},
 				preferencesModal: {

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -93,6 +93,10 @@ consent_modal_description = Einleitung
 consent_modal_settings = Einstellungen
 consent_modal_accept_all = Alle zulassen
 consent_modal_accept_necessary = Nur notwendige zulassen
+consent_modal_equal_weight_buttons = Buttons gleich gewichten
+consent_modal_equal_weight_buttons_yes = Ja (empfohlen)
+consent_modal_equal_weight_buttons_no = Nein, "Alle zulassen" optisch hervorheben (nicht empfohlen)
+
 
 consent_settings = Einstellungs-Dialog
 

--- a/package.yml
+++ b/package.yml
@@ -88,6 +88,7 @@ default_config:
     consent_modal_layout: cloud
     consent_modal_position: bottom center
     consent_modal_swap_buttons: true
+    consent_modal_equal_weight_buttons: false
     consent_settings_layout: box
 
     consent_modal_open: Einstellungen öffnen

--- a/pages/settings.consent.php
+++ b/pages/settings.consent.php
@@ -32,11 +32,18 @@ $select = $field->getSelect();
 $select->addOption('invert buttons', 1);
 $select->addOption('do not invert buttons', 0);
 
+$field = $form->addSelectField('consent_modal_equal_weight_buttons', null, ['class' => 'form-control selectpicker']);
+$field->setLabel($addon->i18n('consent_modal_equal_weight_buttons'));
+$select = $field->getSelect();
+$select->addOption($addon->i18n('consent_modal_equal_weight_buttons_yes'), 1);
+$select->addOption($addon->i18n('consent_modal_equal_weight_buttons_no'), 0);
+
 $field = $form->addSelectField('consent_settings_layout', null, ['class' => 'form-control selectpicker']);
 $field->setLabel($addon->i18n('consent_settings_layout'));
 $select = $field->getSelect();
 $select->addOption('box', 'box');
 $select->addOption('bar', 'bar');
+
 
 $field = $form->addSelectField('disable_page_interaction', null, ['class' => 'form-control selectpicker']);
 $field->setLabel($addon->i18n('disable_page_interaction'));


### PR DESCRIPTION
Kundenwunsch (Schweiz), nicht empfohlen im EU-Raum