### PR TITLE
Übersetzungen der Config-Texte korrigiert

### DIFF
--- a/lib/Wsm.php
+++ b/lib/Wsm.php
@@ -272,8 +272,8 @@ class Wsm
 
         $text = self::getConfig($key, 'string');
         if (rex_addon::get('sprog')->isAvailable() && !rex::isSafeMode()) {
-            if (false !== sprogcard($key, $clang_id)) {
-                $text = sprogcard($key, $clang_id);
+            if (false !== sprogcard($text, $clang_id)) {
+                $text = sprogcard($text, $clang_id);
             }
         }
 


### PR DESCRIPTION
Damit der in den Einstellungen hinterlegte Sprog-key geprüft wird, muss der Wert des Feldes und nicht der Config-Key übergeben werden. Falls die Funktionalität jedoch so gedacht war, dass der tatsächliche Config-Key in Sprog hinterlegt werden muss, so sollte dieser als Notiz am Feld ergänzt werden. Die Hilfe liest sich aber eher so, dass man beliebige Sprog-Keys in den Textefeldern hinterlegen können soll