### PR TITLE
Anpassung Optik an https://playground.cookieconsent.orestbida.com/

### DIFF
--- a/fragments/wsm.js.php
+++ b/fragments/wsm.js.php
@@ -41,13 +41,14 @@ use rex_clang;
 
 			guiOptions: {
 				consentModal: {
-					layout: '<?= Wsm::getConfig('consent_settings_layout', 'string', '') ?>',
+					layout: '<?= Wsm::getConfig('consent_modal_layout', 'string', '') ?>',
 					position: '<?= Wsm::getConfig('consent_modal_position', 'string', '') ?>',
-					equalWeightButtons: <?= Wsm::getConfig('consent_modal_equal_weight_buttons', 'bool', null) ? 'true' : 'false' ?>,
-					flipButtons: <?= Wsm::getConfig('consent_modal_swap_buttons', 'bool', null) ? 'true' : 'false' ?>,
+					equalWeightButtons: <?= Wsm::getConfig('consent_modal_equal_weight_buttons', 'bool') ? 'true' : 'false' ?>,
+					flipButtons: <?= Wsm::getConfig('consent_modal_swap_buttons', 'bool') ? 'true' : 'false' ?>,
 				},
 				preferencesModal: {
 					layout: '<?= Wsm::getConfig('consent_settings_layout', 'string', '') ?>',
+                    position: '<?= Wsm::getConfig('consent_settings_position', 'string', '') ?>',
 					equalWeightButtons: true,
 					flipButtons: <?= Wsm::getConfig('consent_modal_swap_buttons', 'bool') ? 'true' : 'false' ?>,
 				},

--- a/fragments/wsm.js.php
+++ b/fragments/wsm.js.php
@@ -48,7 +48,7 @@ use rex_clang;
 				},
 				preferencesModal: {
 					layout: '<?= Wsm::getConfig('consent_settings_layout', 'string', '') ?>',
-                    position: '<?= Wsm::getConfig('consent_settings_position', 'string', '') ?>',
+					position: '<?= Wsm::getConfig('consent_settings_position', 'string', '') ?>',
 					equalWeightButtons: true,
 					flipButtons: <?= Wsm::getConfig('consent_modal_swap_buttons', 'bool') ? 'true' : 'false' ?>,
 				},

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -82,6 +82,7 @@ consent_modal_position = Position
 consent_modal_swap_buttons = Button-Reihenfolge umgekehren
 
 consent_settings_layout = Layout (Erweiterte Einstellungen)
+consent_settings_position = Position (Erweiterte Einstellungen)
 disable_page_interaction = Auswahl erzwingen?
 
 # Einstellungsseite Texte
@@ -134,7 +135,7 @@ iframe_load_all_btn = Grundsätzlich erlauben
 
 # Einstellungsseite Demo-Import
 
-wsm_demo_import = Demo-Daten importieren (ohne jegliche Gewähr, projektspezifische Anpassungen müssen von Betreiber und Entwickler gemeinsam vorgenommen werden.)
+wsm_demo_import = Demo-Daten imporiteren (ohne jegliche Gewähr, projektspezifische Anpassungen müssen von Betreiber und Entwickler gemeinsam vorgenommen werden.)
 wsm_demo = Demo-Daten importieren
 wsm_demo_warning = Achtung, jetzt wird's ernst! Alle bisher gewählten Drittanbieter-Gruppen und Einstellungen gehen verloren. Wirklich fortfahren?
 wsm_demo_imported = Alle Demo-Daten wurden importiert. Als nächstes Demo-Daten anpassen!

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -135,7 +135,7 @@ iframe_load_all_btn = Grundsätzlich erlauben
 
 # Einstellungsseite Demo-Import
 
-wsm_demo_import = Demo-Daten imporiteren (ohne jegliche Gewähr, projektspezifische Anpassungen müssen von Betreiber und Entwickler gemeinsam vorgenommen werden.)
+wsm_demo_import = Demo-Daten importieren (ohne jegliche Gewähr, projektspezifische Anpassungen müssen von Betreiber und Entwickler gemeinsam vorgenommen werden.)
 wsm_demo = Demo-Daten importieren
 wsm_demo_warning = Achtung, jetzt wird's ernst! Alle bisher gewählten Drittanbieter-Gruppen und Einstellungen gehen verloren. Wirklich fortfahren?
 wsm_demo_imported = Alle Demo-Daten wurden importiert. Als nächstes Demo-Daten anpassen!

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -82,6 +82,7 @@ consent_modal_position = Position
 consent_modal_swap_buttons = Swap button order
 
 consent_settings_layout = Layout (Advanced Settings)
+consent_settings_position = Position (Advanced Settings)
 disable_page_interaction = Force selection?
 
 # Settings page Texts

--- a/pages/settings.consent.php
+++ b/pages/settings.consent.php
@@ -10,20 +10,24 @@ $field = $form->addSelectField('consent_modal_layout', null, ['class' => 'form-c
 $field->setLabel($addon->i18n('consent_modal_layout'));
 $select = $field->getSelect();
 $select->addOption('cloud', 'cloud');
+$select->addOption('cloud-inline', 'cloud-inline');
 $select->addOption('box', 'box');
+$select->addOption('box-inline', 'box-inline');
+$select->addOption('box-wide', 'box-wide');
 $select->addOption('bar', 'bar');
+$select->addOption('bar-inline', 'bar-inline');
 
 $field = $form->addSelectField('consent_modal_position', null, ['class' => 'form-control selectpicker']);
 $field->setLabel($addon->i18n('consent_modal_position'));
 $select = $field->getSelect();
 $select->addOption('bottom left', 'bottom left');
-$select->addOption('bottom middle', 'bottom middle');
+$select->addOption('bottom center', 'bottom center');
 $select->addOption('bottom right', 'bottom right');
 $select->addOption('middle left', 'middle left');
-$select->addOption('middle middle', 'middle middle');
+$select->addOption('middle center', 'middle center');
 $select->addOption('middle right', 'middle right');
 $select->addOption('top left', 'top left');
-$select->addOption('top middle', 'top middle');
+$select->addOption('top center', 'top center');
 $select->addOption('top right', 'top right');
 
 $field = $form->addSelectField('consent_modal_swap_buttons', null, ['class' => 'form-control selectpicker']);
@@ -43,6 +47,12 @@ $field->setLabel($addon->i18n('consent_settings_layout'));
 $select = $field->getSelect();
 $select->addOption('box', 'box');
 $select->addOption('bar', 'bar');
+
+$field = $form->addSelectField('consent_settings_position', null, ['class' => 'form-control selectpicker']);
+$field->setLabel($addon->i18n('consent_settings_position'));
+$select = $field->getSelect();
+$select->addOption('left', 'left');
+$select->addOption('right', 'right');
 
 $field = $form->addSelectField('disable_page_interaction', null, ['class' => 'form-control selectpicker']);
 $field->setLabel($addon->i18n('disable_page_interaction'));


### PR DESCRIPTION
Die Layout-Optionen waren nicht ganz passend mit den "originalen" von https://playground.cookieconsent.orestbida.com/ weshalb die Einstellungen teilweise keine Wirkung hatten und man bestimmte Layout und POsitionen nciht wählen konnte.

Dieser PR behebt das.