### PR TITLE
Neu: Nachträgliches Öffnen des Einstellungsfensters

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ z.B. für Google Maps
 
 Siehe <https://github.com/orestbida/iframemanager#configuration-options>.
 
+#### Nachträgliches Öffnen des Einstellungsfensters
+Die Klasse `wsm-show` z.B. auf einem Link öffnet den Consent-Manager im Nachhinein.
+
+Bsp.: `<a class="wsm-show">Datenschutz-Einstellungen</a>`
+
 #### Themes
 
 Siehe <https://cookieconsent.orestbida.com/advanced/ui-customization.html#color-schemes>

--- a/fragments/wsm.js.php
+++ b/fragments/wsm.js.php
@@ -97,6 +97,11 @@ use rex_clang;
 				body: formData
 			});
 		}
+
+        function openWsmConsentModal() {
+            wsm_cc.showPreferences();
+        }
+
 		/* Consent Details https://gist.github.com/orestbida/62ac9787123c841fa2448e91573bf22b */
 		const updateConsentDetails = (modal) => {
 
@@ -131,5 +136,9 @@ use rex_clang;
 				addEventListener('cc:onChange', () => updateConsentDetails(modal));
 			}
 		});
+
+        if(document.querySelector('.wsm-show')){
+            document.querySelector('.wsm-show').addEventListener('click', openWsmConsentModal);
+        }
 	});
 </script>


### PR DESCRIPTION
Die Klasse `.wsm-show` auf z.B. einem Link ermöglicht das Öffnen des Modals im Nachhinein.